### PR TITLE
feat: update titleTemplate to remove VitePress suffix

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -1,4 +1,5 @@
 export default {
+  titleTemplate: ':title',
   
   locales: {
     // The key is the path for the locale to be nested under.
@@ -30,7 +31,7 @@ export default {
   
   
   themeConfig: {
-    siteTitle: '{Adina.',
+    siteTitle: 'Adina Foxová',
     
     /* locales: {
       '/': {


### PR DESCRIPTION
This PR updates the `titleTemplate` in `docs/.vitepress/config.js` to prevent the default '| VitePress' suffix from being added to the page titles.